### PR TITLE
Draft: add corpus-aware agent guardrails

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,4 @@
+[mcp_servers.oldtupi_authoring]
+command = "python3"
+args = ["-m", "authoring.mcp_server"]
+cwd = "../oldtupicorpus"

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "oldtupi-authoring": {
+      "command": "python3",
+      "args": ["-m", "authoring.mcp_server"],
+      "cwd": "../oldtupicorpus"
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# Nhe'enga Agent Rules
+
+This repository implements reusable morphology and the Pydicate DSL. It is not a place to force a single corpus line to render as desired.
+
+## Before an engine edit
+
+- Read the relevant `oldtupicorpus` source record, target, and expression-level candidate first.
+- Do not change engine code until the human editor has approved the linguistic analysis and established that the source expression alone cannot represent it.
+- Identify the smallest behavior being changed and at least one contrast that must remain unchanged.
+- Add or update a focused executable regression before broad refactoring.
+
+## Required verification
+
+1. Run the smallest relevant harness or focused script.
+2. Run the corresponding `oldtupicorpus` source/ground-truth verification when a historic rendering is affected.
+3. Record the historic attestation and contrast in the change note or test comment.
+
+## Boundaries
+
+- Do not modify `ground_truth` from this repository.
+- Do not broaden a special case from one construction to all generic/person/object forms without tests for each affected branch.
+- Prefer small reviewable diffs. Do not run parallel agents that edit the same morphology modules.
+
+The authoring MCP server lives in the sibling `../oldtupicorpus` checkout. It is useful for retrieving source context and rendering candidates, but it intentionally cannot write files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# Claude Code instructions
+
+Read `AGENTS.md` first. This repository is the reusable Old Tupi morphology and Pydicate engine.
+
+Before changing morphology code for a corpus line:
+
+1. Use the sibling `oldtupi-authoring` MCP tools to inspect the relevant source record and precedents.
+2. Confirm that the human editor has approved the linguistic analysis.
+3. Show why the problem cannot be represented at the source-expression level.
+4. Add a focused regression and identify a contrast that must remain unchanged.
+5. Run focused checks and then the affected corpus verification in `../oldtupicorpus`.
+
+Never change the engine merely to force one source target to pass. Do not modify corpus ground truth from this repository.

--- a/tupi/AGENTS.md
+++ b/tupi/AGENTS.md
@@ -1,0 +1,11 @@
+# Tupi morphology implementation rules
+
+Changes here can alter many source renderings indirectly.
+
+- Treat each change as a behavior change, not as an orthographic patch.
+- State the input construction, intended output, and the nearest contrasting construction before editing.
+- Preserve distinctions between lexical forms, incorporated forms, deverbal forms, and person/mood inflection unless an approved analysis explicitly unifies them.
+- Add a narrow regression close to the affected behavior. A historical source line is evidence, but it is not sufficient as the only regression.
+- Run the affected corpus comparison after a successful focused test.
+
+For uncertain historic analyses, stop at a candidate expression and return the uncertainty to the human editor rather than encoding a speculative engine rule.


### PR DESCRIPTION
## What this adds

- root and `tupi/` agent rules for morphology-engine changes
- Claude instructions with the same source-context-first workflow
- project-local Codex and Claude-style MCP configuration pointing at sibling `../oldtupicorpus`

## Intended behavior

Agents must inspect the approved corpus record and expression-level alternatives before changing morphology code. Engine changes require focused regressions and a preserved contrast; this repository never owns ground-truth edits.

## Review note

This is intentionally documentation/configuration only. It does not change morphology behavior.